### PR TITLE
Fixed missing optional argument added in DRF 2.3.14

### DIFF
--- a/example/api/serializers.py
+++ b/example/api/serializers.py
@@ -16,9 +16,9 @@ class PostSerializer(serializers.ModelSerializer):
     photos = serializers.HyperlinkedIdentityField('photos', view_name='postphoto-list')
     # author = serializers.HyperlinkedRelatedField(view_name='user-detail', lookup_field='username')
     
-    def get_validation_exclusions(self):
+    def get_validation_exclusions(self, instance=None):
         # Need to exclude `user` since we'll add that later based off the request
-        exclusions = super(PostSerializer, self).get_validation_exclusions()
+        exclusions = super(PostSerializer, self).get_validation_exclusions(instance=instance)
         return exclusions + ['author']
     
     class Meta:


### PR DESCRIPTION
DRF 2.3.14 adds an optional argument to `get_validation_exlusions`:
https://github.com/tomchristie/django-rest-framework/commit/51e6982397cc032d6b3fd66f452713d448eb9084

We override that method to ignore the user FK which we add ourselves.

Fixes #7.
