### PR TITLE
serializers AssertionError since 3.3.0

### DIFF
--- a/example/api/serializers.py
+++ b/example/api/serializers.py
@@ -23,6 +23,7 @@ class PostSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Post
+        fields = '__all__'
 
 
 class PhotoSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0.
Add an explicit fields = '__all__' to the PostSerializer serializer.